### PR TITLE
サイド＆ボトムメニューの作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -5,6 +5,7 @@
 @import "./loading.css";
 @import "./star_rating.css";
 @import "./top.css";
+@import "./sidebar.css";
 
 @tailwind base;
 @tailwind components;

--- a/app/assets/stylesheets/sidebar.css
+++ b/app/assets/stylesheets/sidebar.css
@@ -1,0 +1,25 @@
+/* YouTube風サイドバー縮小時のスタイル */
+.drawer-side aside[data-collapsed="true"] .sidebar-text {
+  display: none;
+}
+
+.drawer-side aside[data-collapsed="true"] .sidebar-title {
+  display: none;
+}
+
+.drawer-side aside[data-collapsed="true"] .sidebar-border {
+  border: none;
+  padding: 0.5rem 0;
+}
+
+.drawer-side aside[data-collapsed="true"] .sidebar-link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 0.5rem;
+}
+
+.drawer-side aside[data-collapsed="true"] .sidebar-link i {
+  font-size: 1.25rem;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,15 @@ class ApplicationController < ActionController::Base
   before_action :require_login
   add_flash_types :success, :danger
 
+  # サイドバー切り替え用のアクション
+  def sidebar_mini
+    render partial: 'shared/sidebar_mini', layout: false
+  end
+
+  def sidebar_full
+    render partial: 'shared/sidebar', layout: false
+  end
+
   private
 
   def require_login

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,17 @@ module ApplicationHelper
     version = version_display(date.to_date)
     "#{formatted_date}前 / #{version}"
   end
+
+  # サイドバーの状態管理
+  def sidebar_collapsed?
+    cookies[:sidebar_collapsed] == 'true'
+  end
+
+  def sidebar_width_class
+    sidebar_collapsed? ? 'w-16' : 'w-52'
+  end
+
+  def main_content_margin_class
+    sidebar_collapsed? ? 'lg:ml-16' : 'lg:ml-52'
+  end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("loading", LoadingController)
 
 import aos_frame_controller from "./aos_frame_controller"
 application.register("aos-frame", aos_frame_controller)
+
+import sidebar_controller from "./sidebar_controller"
+application.register("sidebar", sidebar_controller)

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -1,0 +1,114 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+
+  connect() {
+    // ページ読み込み時：保存された状態を復元
+    this.restoreSidebarState()
+  }
+
+  toggle() {
+    // ハンバーガーメニューがクリックされた時の処理
+
+    // 1. 必要な要素を取得
+    const sidebar = document.querySelector('aside')
+    const mainContent = document.querySelector('.lg\\:ml-52, .lg\\:ml-16')
+
+    // 2. 要素が見つからない場合は処理を中止
+    if (!sidebar || !mainContent) return
+
+    // 3. 現在の状態を確認
+    const isCurrentlyCollapsed = sidebar.classList.contains('w-16')
+
+    if (isCurrentlyCollapsed) {
+      // 現在縮小状態 → 展開する
+      this.expandSidebar(sidebar, mainContent)
+      this.saveState('expanded')
+    } else {
+      // 現在展開状態 → 縮小する
+      this.collapseSidebar(sidebar, mainContent)
+      this.saveState('collapsed')
+    }
+  }
+
+  // サイドバーを縮小する
+  collapseSidebar(sidebar, mainContent) {
+    // サイドバーの幅を小さく
+    sidebar.classList.remove('w-52')
+    sidebar.classList.add('w-16')
+
+    // メインコンテンツのマージンを調整
+    mainContent.classList.remove('lg:ml-52')
+    mainContent.classList.add('lg:ml-16')
+
+    // 縮小版のHTMLを読み込み
+    this.loadSidebarContent('mini')
+  }
+
+  // サイドバーを展開する
+  expandSidebar(sidebar, mainContent) {
+    // サイドバーの幅を大きく
+    sidebar.classList.remove('w-16')
+    sidebar.classList.add('w-52')
+
+    // メインコンテンツのマージンを調整
+    mainContent.classList.remove('lg:ml-16')
+    mainContent.classList.add('lg:ml-52')
+
+    // 通常版のHTMLを読み込み
+    this.loadSidebarContent('full')
+  }
+
+  // サイドバーのHTMLを読み込む
+  loadSidebarContent(type) {
+    const sidebarContainer = document.querySelector('[data-sidebar-target="sidebar"]')
+
+    if (!sidebarContainer) return
+
+    // サーバーからHTMLを取得
+    const url = type === 'mini' ? '/sidebar_mini' : '/sidebar_full'
+
+    fetch(url)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error('サーバーからの応答がエラーでした')
+        }
+        return response.text()
+      })
+      .then(html => {
+        // 取得したHTMLを画面に表示
+        sidebarContainer.innerHTML = html
+      })
+      .catch(error => {
+        console.error('サイドバーの読み込みに失敗しました:', error)
+      })
+  }
+
+  // 状態をブラウザに保存
+  saveState(state) {
+    // localStorage: ブラウザを閉じても残る
+    localStorage.setItem('sidebarState', state)
+
+    // Cookie: サーバーサイドでも読み取れる 3日間
+    document.cookie = `sidebar_collapsed=${state === 'collapsed'}; path=/; max-age=259200`
+  }
+
+  // 保存された状態を復元
+  restoreSidebarState() {
+    // 保存された状態を取得
+    const savedState = localStorage.getItem('sidebarState')
+
+    // 保存された状態がない場合は何もしない（デフォルト：展開状態）
+    if (!savedState) return
+
+    // 縮小状態で保存されていた場合のみ復元
+    if (savedState === 'collapsed') {
+      const sidebar = document.querySelector('aside')
+      const mainContent = document.querySelector('.lg\\:ml-52, .lg\\:ml-16')
+
+      if (sidebar && mainContent) {
+        this.collapseSidebar(sidebar, mainContent)
+      }
+    }
+  }
+}

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -6,91 +6,43 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
 
-  <% if Rails.env.development? %>
-    <link href="https://cdn.jsdelivr.net/npm/daisyui@5.0.9" rel="stylesheet" type="text/css" />
-    <script src="https://cdn.tailwindcss.com?version=3.4.16"></script>
-      <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
-      <%= stylesheet_link_tag "tailwind", media: "all", "data-turbo-track": "reload" %>
-    <% else %>
-      <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
-      <%= stylesheet_link_tag "tailwind", media: "all", "data-turbo-track": "reload" %>
-    <% end %>
-
-  <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+  <%= stylesheet_link_tag "application", media: "all", "data-turbo-track": "reload" %>
+  <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 </head>
 
-<body class="min-h-screen">
-  <div class="flex">
-    <!-- サイドバー -->
-
-    <div class="bg-base-200 min-h-screen w-52 shadow-inner">
-      <div class="flex p-4 items-center">
-        <h1 class="text-2xl font-bold">管理パネル</h1>
-        <%= render 'shared/theme_toggle' %>
+  <body>
+    <%# loadingアニメーション %>
+    <div class="flex flex-col min-h-screen" data-controller="loading">
+      <div data-loading-target="spinner" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 hidden">
+        <div class="h-[50px] w-[50px] flex items-center justify-center">
+          <span class="loading loading-spinner text-default w-full h-full"></span>
+        </div>
       </div>
 
-      <nav class="mt-2 py-2">
-        <ul>
-          <li><%= link_to "ダッシュボード", admin_path, class: "block px-4 py-2 w-full h-full hover:bg-base-300" %></li>
-          <li><%= link_to "ユーザー管理", admin_users_path, class: "block px-4 py-2 w-full h-full hover:bg-base-300" %></li>
-          <li><%= link_to "キャラクター管理", admin_characters_path, class: "block px-4 py-2 w-full h-full hover:bg-base-300" %></li>
-        </ul>
-      </nav>
+      <%# メイン部分 %>
+      <div class="flex flex-grow">
+        <!-- 通常のレイアウト -->
+        <div class="flex w-full">
+          <!-- サイドバー -->
+          <aside class="hidden lg:block w-52 min-h-screen bg-base-200 transition-all duration-300 fixed left-0 z-30">
+            <%= render 'shared/sidebar' %>
+          </aside>
 
-      <div class="mt-10 py-2">
-        <h2 class="text-lg font-bold px-4 mb-2">-SEARCH-</h2>
-        <ul>
-          <li class="hover:bg-base-300">
-            <%= link_to '編成動画検索', posts_path, class: "block px-4 py-2 w-full h-full" %>
-          </li>
-          <li class="hover:bg-base-300">
-            <%= link_to '編成一覧検索', '#', class: "block px-4 py-2 w-full h-full" %>
-          </li>
-        </ul>
-      </div>
+          <!-- メインコンテンツエリア -->
+          <div class="flex-1 lg:ml-52 w-full">
+            <%# メインコンテンツ %>
+            <main class="p-4 lg:p-6 overflow-x-hidden">
+              <%= render 'shared/flash_message' %>
+              <%= yield %>
+            </main>
 
-      <div class="py-2">
-        <h2 class="text-lg font-bold px-4 mb-2">-SHARE-</h2>
-        <ul>
-          <li class="hover:bg-base-300">
-            <%= link_to 'おすすめ動画シェア', new_post_path, class: "block px-4 py-2 w-full h-full" %>
-          </li>
-          <li class="hover:bg-base-300">
-            <%= link_to '編成評価', '#', class: "block px-4 py-2 w-full h-full" %>
-          </li>
-        </ul>
-      </div>
-
-      <div class="py-2">
-        <h2 class="text-lg font-bold px-4 mb-2">-マイリスト-</h2>
-        <ul>
-          <li class="hover:bg-base-300">
-            <%= link_to 'マイシェアリスト', '#', class: "block px-4 py-2 w-full h-full" %>
-          </li>
-          <li class="hover:bg-base-300">
-            <%= link_to 'お気に入りリスト', '#', class: "block px-4 py-2 w-full h-full" %>
-          </li>
-        </ul>
+            <%# スマホ用固定ボトムナビゲーション %>
+            <div class="lg:hidden">
+              <%= render 'shared/bottom_navigation' %>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-
-
-    <!-- メインコンテンツ -->
-    <div class="flex-1 p-8">
-      <% if notice.present? %>
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4">
-          <%= notice %>
-        </div>
-      <% end %>
-
-      <% if alert.present? %>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-          <%= alert %>
-        </div>
-      <% end %>
-
-      <%= yield %>
-    </div>
-  </div>
-</body>
+  </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,22 +35,41 @@
         <% end %>
       </div>
 
-      <!-- メイン部分 -->
+      <%# メイン部分 %>
       <div class="flex flex-grow mt-16">
         <% if ['top'].include?(controller_name) %>
-          <!-- サイドバーがない場合 -->
+          <!-- トップページ：サイドバーなし -->
           <div class="flex-1 w-full">
             <%= render 'shared/flash_message' %>
             <%= yield %>
           </div>
         <% else %>
-          <div id="sidebar" data-sidebar-target="sidebar" class="hidden md:block fixed top-[64px] left-0 h-screen w-52 bg-base-200 overflow-y-auto z-30">
-            <%= render 'shared/sidebar' %>
-          </div>
-          <!-- サイドバーがある場合 -->
-          <div class="flex-1 md:ml-52 p-4 w-full overflow-x-hidden">
-            <%= render 'shared/flash_message' %>
-            <%= yield %>
+          <!-- 通常のレイアウト -->
+          <div class="flex w-full">
+            <!-- サイドバー -->
+            <aside class="hidden lg:block <%= sidebar_width_class %> min-h-screen bg-base-200 transition-all duration-300 fixed top-16 left-0 z-30">
+              <div data-sidebar-target="sidebar">
+                <% if sidebar_collapsed? %>
+                  <%= render 'shared/sidebar_mini' %>
+                <% else %>
+                  <%= render 'shared/sidebar' %>
+                <% end %>
+              </div>
+            </aside>
+
+            <!-- メインコンテンツエリア -->
+            <div class="flex-1 <%= main_content_margin_class %> w-full">
+              <%# メインコンテンツ %>
+              <main class="p-4 lg:p-6 overflow-x-hidden">
+                <%= render 'shared/flash_message' %>
+                <%= yield %>
+              </main>
+
+              <%# スマホ用固定ボトムナビゲーション %>
+              <div class="lg:hidden">
+                <%= render 'shared/bottom_navigation' %>
+              </div>
+            </div>
           </div>
         <% end %>
       </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,6 +1,15 @@
 <div class="navbar bg-base-200 shadow-sm">
-  <div class="flex-1">
-    <%= link_to t('header.title'), '/', class: 'btn btn-ghost text-xl' %>
+  <div class="flex-1 flex">
+    <%# サイドバーページでのみハンバーガーメニューを表示（デスクトップのみ） %>
+    <% unless ['top'].include?(controller_name) %>
+      <%# デスクトップ用：サイドバー縮小/展開 %>
+      <button class="btn btn-ghost btn-circle hidden lg:flex"
+              data-action="click->sidebar#toggle">
+        <i class="fas fa-bars text-lg"></i>
+      </button>
+    <% end %>
+
+    <%= link_to t('header.title'), '/', class: 'btn btn-ghost text-xl ml-2' %>
   </div>
   <div class="flex gap-2">
     <%= render 'shared/theme_toggle' %>

--- a/app/views/shared/_bottom_navigation.html.erb
+++ b/app/views/shared/_bottom_navigation.html.erb
@@ -1,0 +1,81 @@
+<div class="fixed bottom-0 left-0 right-0 bg-base-300 border-t border-base-content/10 z-40">
+  <div class="flex justify-between h-16 mx-8">
+
+    <%# おすすめ動画 %>
+    <%= link_to posts_path,
+        class: "flex flex-col items-center justify-center space-y-1 hover:bg-base-content/10 transition-colors #{request.path == posts_path ? 'text-primary' : 'text-base-content/70'}",
+        data: { action: "click->loading#show" } do %>
+      <i class="fab fa-youtube text-lg"></i>
+      <span class="text-xs">動画</span>
+    <% end %>
+
+    <%# 編成評価 %>
+    <%= link_to teams_path,
+        class: "flex flex-col items-center justify-center space-y-1 hover:bg-base-content/10 transition-colors #{request.path == teams_path ? 'text-primary' : 'text-base-content/70'}",
+        data: { action: "click->loading#show" } do %>
+      <i class="fas fa-users text-lg"></i>
+      <span class="text-xs">編成</span>
+    <% end %>
+
+    <%# シェア %>
+    <div class="dropdown dropdown-top dropdown-end">
+      <div tabindex="0" role="button" class="flex flex-col items-center justify-center space-y-1 hover:bg-base-content/10 transition-colors text-base-content/70 w-full h-full">
+        <i class="fas fa-plus-circle text-lg"></i>
+        <span class="text-xs">シェア</span>
+      </div>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-48 mb-2">
+        <li>
+          <%= link_to new_post_path, data: { action: "click->loading#show" } do %>
+            <i class="fas fa-external-link-alt"></i>
+            動画シェア
+          <% end %>
+        </li>
+        <li>
+          <%= link_to new_team_rating_path, data: { action: "click->loading#show" } do %>
+            <i class="fas fa-star"></i>
+            編成評価
+          <% end %>
+        </li>
+      </ul>
+    </div>
+
+    <%# マイページ %>
+    <%= link_to mypage_path(tab: 'posts'),
+        class: "flex flex-col items-center justify-center space-y-1 hover:bg-base-content/10 transition-colors #{request.path == mypage_path(tab: 'posts') ? 'text-primary' : 'text-base-content/70'}",
+        data: { action: "click->loading#show" } do %>
+      <i class="fas fa-home text-lg"></i>
+      <span class="text-xs">マイページ</span>
+    <% end %>
+
+    <%# 管理者 %>
+    <% if current_user&.role == 1 || current_user&.admin? %>
+      <div class="dropdown dropdown-top dropdown-end">
+        <div tabindex="0" role="button" class="flex flex-col items-center justify-center space-y-1 hover:bg-base-content/10 transition-colors text-base-content/70 w-full h-full">
+          <i class="fas fa-user-lock text-lg"></i>
+          <span class="text-xs">管理者</span>
+        </div>
+        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-48 mb-2">
+          <li>
+            <%= link_to admin_root_path, data: { action: "click->loading#show" } do %>
+              <i class="fas fa-cog"></i>
+              管理者画面
+            <% end %>
+          </li>
+          <li>
+            <%= link_to admin_users_path, data: { action: "click->loading#show" } do %>
+              <i class="fas fa-users-cog"></i>
+              ユーザー管理
+            <% end %>
+          </li>
+          <li>
+            <%= link_to admin_characters_path, data: { action: "click->loading#show" } do %>
+              <i class="fas fa-user-friends"></i>
+              キャラクター管理
+            <% end %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,17 @@
-<div class="navbar bg-base-300 shadow-sm">
-  <div class="flex-1">
-    <%= link_to t('header.title'), '/', class: 'btn btn-ghost text-xl' %>
+<div class="navbar bg-base-300 shadow-sm" data-controller="sidebar">
+  <div class="flex-1 flex">
+    <%# サイドバーページでのみハンバーガーメニューを表示（デスクトップのみ） %>
+    <% unless ['top'].include?(controller_name) %>
+      <%# デスクトップ用：サイドバー縮小/展開 %>
+      <button class="btn btn-ghost btn-circle hidden lg:flex"
+              data-action="click->sidebar#toggle">
+        <i class="fas fa-bars text-lg"></i>
+      </button>
+    <% end %>
+
+    <%= link_to t('header.title'), '/', class: 'btn btn-ghost text-xl ml-2' %>
   </div>
+
   <div class="flex gap-2">
     <%# テーマ切り替え %>
     <%= render 'shared/theme_toggle' %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,40 +1,70 @@
-<div class="bg-base-200 min-h-screen w-52 shadow-inner">
-  <div class="py-4">
-    <h2 class="text-lg font-bold px-4 mb-2">-検索-</h2>
+<div class="bg-base-200 min-h-screen w-full shadow-inner">
+  <div class="py-4 sidebar-border border-b border-gray-500">
+    <h2 class="sidebar-title text-lg font-bold px-4 mb-2">-検索-</h2>
     <ul>
       <li class="hover:bg-base-300">
-        <%= link_to 'おすすめ動画', posts_path, class: "block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } %>
+        <%= link_to posts_path, class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+          <i class="fab fa-youtube"></i>
+          <span class="sidebar-text ml-2">おすすめ動画</span>
+        <% end %>
       </li>
       <li class="hover:bg-base-300">
-        <%= link_to '編成評価', teams_path, class: "block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } %>
+        <%= link_to teams_path, class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+         <i class="fas fa-users"></i>
+         <span class="sidebar-text ml-2">編成評価</span>
+        <% end %>
       </li>
     </ul>
   </div>
 
-  <div class="py-4">
-    <h2 class="text-lg font-bold px-4 mb-2">-シェア-</h2>
+  <div class="py-4 sidebar-border border-b border-gray-500">
+    <h2 class="sidebar-title text-lg font-bold px-4 mb-2">-シェア-</h2>
     <ul>
       <li class="hover:bg-base-300">
-        <%= link_to 'おすすめ動画', new_post_path, class: "block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } %>
+        <%= link_to new_post_path, class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+        <i class="fas fa-external-link-alt"></i>
+        <span class="sidebar-text ml-2">おすすめ動画シェア</span>
+        <% end %>
       </li>
       <li class="hover:bg-base-300">
-        <%= link_to '編成評価', new_team_rating_path, class: "block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } %>
+        <%= link_to new_team_rating_path, class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+        <i class="fas fa-star"></i>
+        <span class="sidebar-text ml-2">編成評価</span>
+        <% end %>
       </li>
     </ul>
+  </div>
+
+  <div class="py-4 sidebar-border border-b border-gray-500">
+      <div class="hover:bg-base-300">
+        <%= link_to mypage_path(tab: 'posts'), class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+          <i class="fas fa-home"></i>
+          <span class="sidebar-text ml-2">マイページ</span>
+        <% end %>
+      </div>
   </div>
 
   <div class="py-4">
     <% if current_user&.role == 1 || current_user&.admin? %>
-      <h2 class="text-lg font-bold px-4 mb-2">-管理者パネル-</h2>
+      <h2 class="sidebar-title text-lg font-bold px-4 mb-2">-管理者パネル-</h2>
       <ul>
         <li class="hover:bg-base-300">
-          <%= link_to '管理画面', admin_root_path, class: "block px-4 py-2 w-full h-full" %>
+          <%= link_to admin_root_path, class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+            <i class="fas fa-cog"></i>
+            <span class="sidebar-text ml-2">管理画面</span>
+          <% end %>
         </li>
         <li class="hover:bg-base-300">
-          <%= link_to 'ユーザー管理', admin_users_path, class: "block px-4 py-2 w-full h-full" %>
+          <%= link_to admin_users_path, class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+            <i class="fas fa-users-cog"></i>
+            <span class="sidebar-text ml-2">ユーザー管理</span>
+          <% end %>
         </li>
         <li class="hover:bg-base-300">
-          <%= link_to 'キャラクター管理', admin_characters_path, class: "block px-4 py-2 w-full h-full" %>
+          <%= link_to admin_characters_path, class: "sidebar-link block px-4 py-2 w-full h-full", data: { action: "click->loading#show" } do %>
+            <i class="fas fa-user-friends"></i>
+            <span class="sidebar-text ml-2">キャラクター管理</span>
+          <% end %>
         </li>
       </ul>
     <% end %>

--- a/app/views/shared/_sidebar_mini.html.erb
+++ b/app/views/shared/_sidebar_mini.html.erb
@@ -1,0 +1,85 @@
+<div class="bg-base-200 min-h-screen w-full shadow-inner">
+  <div class="flex flex-col items-center py-4 space-y-2">
+
+    <%# おすすめ動画 %>
+    <%= link_to posts_path,
+        class: "flex flex-col items-center justify-center p-3 rounded-lg hover:bg-base-content/10 transition-colors #{request.path == posts_path ? 'text-primary bg-base-content/5' : 'text-base-content/70'}",
+        data: { action: "click->loading#show" } do %>
+      <i class="fab fa-youtube text-xl"></i>
+    <% end %>
+
+    <%# 編成評価 %>
+    <%= link_to teams_path,
+        class: "flex flex-col items-center justify-center p-3 rounded-lg hover:bg-base-content/10 transition-colors #{request.path == teams_path ? 'text-primary bg-base-content/5' : 'text-base-content/70'}",
+        data: { action: "click->loading#show" } do %>
+      <i class="fas fa-users text-xl"></i>
+    <% end %>
+
+    <%# 区切り線 %>
+    <div class="w-8 h-px bg-base-content/20 my-2"></div>
+
+    <%# シェア %>
+    <div class="dropdown dropdown-right dropdown-middle">
+      <div tabindex="0" role="button" class="flex flex-col items-center justify-center p-3 rounded-lg hover:bg-base-content/10 transition-colors text-base-content/70">
+        <i class="fas fa-plus-circle text-xl"></i>
+      </div>
+      <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-48 ml-2">
+        <li>
+          <%= link_to new_post_path, data: { action: "click->loading#show" } do %>
+            <i class="fas fa-external-link-alt"></i>
+            動画シェア
+          <% end %>
+        </li>
+        <li>
+          <%= link_to new_team_rating_path, data: { action: "click->loading#show" } do %>
+            <i class="fas fa-star"></i>
+            編成評価
+          <% end %>
+        </li>
+      </ul>
+    </div>
+
+    <%# 区切り線 %>
+    <div class="w-8 h-px bg-base-content/20 my-2"></div>
+
+    <%# マイページ %>
+    <%= link_to mypage_path(tab: 'posts'),
+        class: "flex flex-col items-center justify-center p-3 rounded-lg hover:bg-base-content/10 transition-colors #{request.path == mypage_path(tab: 'posts') ? 'text-primary bg-base-content/5' : 'text-base-content/70'}",
+        data: { action: "click->loading#show" } do %>
+      <i class="fas fa-home text-xl"></i>
+    <% end %>
+
+    <%# 管理者 %>
+    <% if current_user&.role == 1 || current_user&.admin? %>
+      <%# 区切り線 %>
+      <div class="w-8 h-px bg-base-content/20 my-2"></div>
+
+      <div class="dropdown dropdown-right dropdown-middle">
+        <div tabindex="0" role="button" class="flex flex-col items-center justify-center p-3 rounded-lg hover:bg-base-content/10 transition-colors text-base-content/70">
+          <i class="fas fa-user-lock text-xl"></i>
+        </div>
+        <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-48 ml-2">
+          <li>
+            <%= link_to admin_root_path, data: { action: "click->loading#show" } do %>
+              <i class="fas fa-cog"></i>
+              管理者画面
+            <% end %>
+          </li>
+          <li>
+            <%= link_to admin_users_path, data: { action: "click->loading#show" } do %>
+              <i class="fas fa-users-cog"></i>
+              ユーザー管理
+            <% end %>
+          </li>
+          <li>
+            <%= link_to admin_characters_path, data: { action: "click->loading#show" } do %>
+              <i class="fas fa-user-friends"></i>
+              キャラクター管理
+            <% end %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,10 @@ Rails.application.routes.draw do
     end
   end
 
+  # サイドバー切り替え用
+  get 'sidebar_mini', to: 'application#sidebar_mini'
+  get 'sidebar_full', to: 'application#sidebar_full'
+
   # プライバシポリシー、利用規約
   get 'privacy', to: 'static_pages#privacy_policy', as: :privacy_policy
   get 'terms', to: 'static_pages#terms_of_use', as: :terms_of_use


### PR DESCRIPTION
## 概要
・Youtube風にサイドバーをしまえるボタンを追加
・スマホサイズの際にボトムメニュー一覧になるように画面調整

## 詳細
- 縮小サイドバーの_sidebar_mini.html.erbを作成
- スマホ用ボトムメニュー_bottom_navigation.html.erbを作成
- sidebar_controller.jsにてサイドバーの縮小・拡大機能の調整（cookieにてちらつき対応）
- application_helper.rbで状態判定のヘルパーをついか
- application.html.erbにてtailwind hiddenなども活用し、各条件での表示を追加
- header.html.erbにてハンバーガーメニュー追加
- routes.rb` + application_controller.rb - で切り替え用API調整